### PR TITLE
Coverage exclusion

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release
     - name: Test and report coverage
-      run: dotnet test --configuration Release --no-build /p:CollectCoverage=true /p:CoverletOutput=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/ /p:MergeWith=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/coverage/ /p:CoverletOutputFormat=opencover /p:ExcludeByFile=\"**/Source/events/*.cs,**/Source/Program.cs\"
+      run: dotnet test --configuration Release --no-build /p:CollectCoverage=true /p:CoverletOutput=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/ /p:MergeWith=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/coverage/ /p:CoverletOutputFormat=opencover /p:ExcludeByFile="**/Source/events/*.cs,**/Source/Program.cs"
 
     - name: 'Azure login'
       uses: azure/docker-login@v1
@@ -84,6 +84,6 @@ jobs:
         sonarProjectKey: RaaLabs_${{ github.event.repository.name }}
         sonarProjectName:  ${{ github.event.repository.name }}
         sonarOrganization: raalabs
-        dotnetTestArguments: --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover /p:ExcludeByFile=\"**/Source/events/*.cs,**/Source/Program.cs\"
+        dotnetTestArguments: --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover /p:ExcludeByFile="**/Source/events/*.cs,**/Source/Program.cs"
         sonarBeginArguments: /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"        
 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release
     - name: Test and report coverage
-      run: dotnet test --configuration Release --no-build /p:CollectCoverage=true /p:CoverletOutput=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/ /p:MergeWith=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/coverage/ /p:CoverletOutputFormat=opencover
+      run: dotnet test --configuration Release --no-build /p:CollectCoverage=true /p:CoverletOutput=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/ /p:MergeWith=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/coverage/ /p:CoverletOutputFormat=opencover /p:ExcludeByFile=\"**/Source/events/*.cs,**/Source/Program.cs\"
 
     - name: 'Azure login'
       uses: azure/docker-login@v1
@@ -84,6 +84,6 @@ jobs:
         sonarProjectKey: RaaLabs_${{ github.event.repository.name }}
         sonarProjectName:  ${{ github.event.repository.name }}
         sonarOrganization: raalabs
-        dotnetTestArguments: --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+        dotnetTestArguments: --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover /p:ExcludeByFile=\"**/Source/events/*.cs,**/Source/Program.cs\"
         sonarBeginArguments: /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"        
 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release
     - name: Test and report coverage
-      run: dotnet test --configuration Release --no-build /p:CollectCoverage=true /p:CoverletOutput=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/ /p:MergeWith=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/coverage/ /p:CoverletOutputFormat=opencover /p:ExcludeByFile="**/Source/events/*.cs,**/Source/Program.cs"
+      run: dotnet test --configuration Release --no-build /p:CollectCoverage=true /p:CoverletOutput=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/ /p:MergeWith=${{ github.workspace }}/${{ env.COVERAGE_FOLDER }}/coverage/ /p:CoverletOutputFormat=opencover
 
     - name: 'Azure login'
       uses: azure/docker-login@v1
@@ -84,6 +84,6 @@ jobs:
         sonarProjectKey: RaaLabs_${{ github.event.repository.name }}
         sonarProjectName:  ${{ github.event.repository.name }}
         sonarOrganization: raalabs
-        dotnetTestArguments: --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover /p:ExcludeByFile="**/Source/events/*.cs,**/Source/Program.cs"
+        dotnetTestArguments: --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
         sonarBeginArguments: /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"        
 

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 using RaaLabs.Edge.Modules.EventHandling;
 using RaaLabs.Edge.Modules.EdgeHub;
 using RaaLabs.Edge.Modules.Configuration;
@@ -9,6 +10,7 @@ using RaaLabs.Edge;
 
 namespace RaaLabs.IdentityMapper
 {
+    [ExcludeFromCodeCoverage]
     class Program
     {
         static void Main(string[] args)

--- a/Source/events/EdgeHubDataPointReceived.cs
+++ b/Source/events/EdgeHubDataPointReceived.cs
@@ -1,7 +1,9 @@
-﻿using RaaLabs.Edge.Modules.EdgeHub;
+﻿using System.Diagnostics.CodeAnalysis;
+using RaaLabs.Edge.Modules.EdgeHub;
 
 namespace RaaLabs.IdentityMapper.events
 {
+    [ExcludeFromCodeCoverage]
     [InputName("events")]
     class EdgeHubDataPointReceived : IEdgeHubIncomingEvent
     {

--- a/Source/events/EdgeHubDataPointRemapped.cs
+++ b/Source/events/EdgeHubDataPointRemapped.cs
@@ -1,7 +1,9 @@
-﻿using RaaLabs.Edge.Modules.EdgeHub;
+﻿using System.Diagnostics.CodeAnalysis;
+using RaaLabs.Edge.Modules.EdgeHub;
 
 namespace RaaLabs.IdentityMapper.events
 {
+    [ExcludeFromCodeCoverage]
     [OutputName("Translated")]
     class EdgeHubDataPointRemapped : IEdgeHubOutgoingEvent
     {


### PR DESCRIPTION
Hi Sigbjørn,

It is possible to exclude code by using the `[ExcludeFromCodeCoverage]` attribute. Its in the `System.Diagnostics.CodeAnalysis;` namespace.

You can see the new coverage (46.9%) here: <https://sonarcloud.io/dashboard?branch=coverage-exclusion&id=RaaLabs_IdentityMapper>

I have tried using the argument `/p:ExcludeByFile="/Source/events/*.cs,/Source/Program.cs"` in the `dotnet test` command, but that did not work. Ill open an issue about his here: <https://github.com/highbyte/sonarscan-dotnet/issues>